### PR TITLE
CachedHaloCatalog now has Lbox attribute as a 3-vector

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@
 
 - Added SubhaloPhaseSpace class for modeling HOD-style satellite velocities with subhalos.
 
-- Added support for the ``Lbox`` keyword passed as a 3-vector to UserSuppliedPtclCatalog and UserSuppliedHaloCatalog. The ``Lbox`` attribute of these classes is now stored as an array of length 3 instead of a scalar.
+- The ``Lbox`` attribute of all Halotools halo catalogs is now stored as an array of length 3 instead of a scalar.
 
 
 0.4 (2016-08-11)

--- a/halotools/sim_manager/cached_halo_catalog.py
+++ b/halotools/sim_manager/cached_halo_catalog.py
@@ -5,6 +5,7 @@ keyword inputs such as ``simname`` and ``redshift``.
 import os
 from warnings import warn
 from copy import deepcopy
+import numpy as np
 
 from astropy.table import Table
 
@@ -569,6 +570,9 @@ class CachedHaloCatalog(object):
         for attr_key in list(f.attrs.keys()):
             if attr_key == 'redshift':
                 setattr(self, attr_key, float(get_redshift_string(f.attrs[attr_key])))
+            elif attr_key == 'Lbox':
+                self.Lbox = np.empty(3)
+                self.Lbox[:] = f.attrs['Lbox']
             else:
                 setattr(self, attr_key, f.attrs[attr_key])
         f.close()
@@ -578,7 +582,7 @@ class CachedHaloCatalog(object):
             for attr in matching_sim._attrlist:
                 if hasattr(self, attr):
                     try:
-                        assert getattr(self, attr) == getattr(matching_sim, attr)
+                        assert np.all(getattr(self, attr) == getattr(matching_sim, attr))
                     except AssertionError:
                         msg = ("The ``" + attr + "`` metadata of the hdf5 file \n"
                             "is inconsistent with the corresponding attribute of the \n" +

--- a/halotools/sim_manager/supported_sims.py
+++ b/halotools/sim_manager/supported_sims.py
@@ -8,6 +8,7 @@ halo catalogs as they are loaded into memory.
 from abc import ABCMeta
 from astropy.extern import six
 from astropy import cosmology
+import numpy as np
 
 __all__ = ('NbodySimulation',
            'Bolshoi', 'BolPlanck', 'MultiDark', 'Consuelo')
@@ -54,7 +55,8 @@ class NbodySimulation(object):
 
         """
         self.simname = simname
-        self.Lbox = Lbox
+        self.Lbox = np.empty(3, dtype='f4')
+        self.Lbox[:] = Lbox
         self.particle_mass = particle_mass
         self.num_ptcl_per_dim = num_ptcl_per_dim
         self.softening_length = softening_length

--- a/halotools/sim_manager/tests/test_supported_sims.py
+++ b/halotools/sim_manager/tests/test_supported_sims.py
@@ -83,3 +83,12 @@ def test_forbidden_sims():
         __ = CachedHaloCatalog(simname='bolplanck', version_name='halotools_alpha_version2')
     substr = "See https://github.com/astropy/halotools/issues/598"
     assert substr in err.value.args[0]
+
+
+def test_lbox_vector():
+    for simname in list(adict.keys()):
+        alist = adict[simname]
+        a = alist[0]
+        z = 1/a - 1
+        halocat = CachedHaloCatalog(simname=simname, redshift=z)
+        assert len(halocat.Lbox) == 3


### PR DESCRIPTION
This is for the sake of consistency between `UserSuppliedHaloCatalog` and `CachedHaloCatalog`. 